### PR TITLE
feat: push image action

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,45 @@
+name: Deploy Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build-image:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        run: |
+          docker build --platform linux/amd64 -t logstore-node -f ./Dockerfile --cache-from type=gha,scope=usherlabs/logstore-node --cache-to type=gha,mode=max,scope=usherlabs/logstore-node .
+
+      - name: Tag image
+        run: |
+          # if master, tag as latest
+          tag=latest
+          # if not master, tag as branch name
+          if [ $GITHUB_REF != 'refs/heads/master' ]; then
+              tag=$(echo $GITHUB_REF | sed 's/refs\/heads\///' | sed 's/\//-/')
+          fi
+          docker tag logstore-node logstore-node:$tag
+          echo "Tagged image as logstore-node:$tag"
+
+      - name: Push image to GitHub Container Registry
+        if: ${{ !env.ACT }} # skip during local actions testing
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker push ghcr.io/$GITHUB_REPOSITORY/logstore-node:$tag
+
+

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -45,13 +45,15 @@ jobs:
           if [ $GITHUB_REF != 'refs/heads/master' ]; then
               tag=$(echo $GITHUB_REF | sed 's/refs\/heads\///' | sed 's/\//-/')
           fi
-          docker tag logstore-node logstore-node:$tag
-          echo "Tagged image as logstore-node:$tag"
+          image_name=${{ env.REGISTRY }}/$GITHUB_REPOSITORY/logstore-node:$tag
+          docker tag logstore-node $image_name
+          echo "Tagged image as $image_name"
+          # save for next step
+          echo "image_name=$image_name" >> $GITHUB_ENV
 
       - name: Push image to GitHub Container Registry
         if: ${{ !env.ACT }} # skip during local actions testing
+        env:
+          IMAGE_NAME: ${{ steps.tag.outputs.image_name }}
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          docker push ghcr.io/$GITHUB_REPOSITORY/logstore-node:$tag
-
-
+          docker push $IMAGE_NAME

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - master
       - develop
-      # temporary
-      - feature/push-image-action
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -16,6 +16,11 @@ jobs:
   deploy:
     name: Deploy Docker Image
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -53,7 +53,5 @@ jobs:
 
       - name: Push image to GitHub Container Registry
         if: ${{ !env.ACT }} # skip during local actions testing
-        env:
-          IMAGE_NAME: ${{ steps.tag.outputs.image_name }}
         run: |
-          docker push $IMAGE_NAME
+          docker push $image_name

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - develop
+      # temporary
+      - feature/push-image-action
 
 jobs:
   build-image:

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        if: ${{ !env.ACT }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -53,7 +54,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          # we push only if env.ACT is not set
+          push: ${{ env.ACT == '' }}
           tags: ${{ env.image_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -9,9 +9,12 @@ on:
       # temporary
       - feature/push-image-action
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
-  build-image:
-    name: Build image
+  deploy:
+    name: Deploy Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,6 +22,13 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        run: |
-          docker build --platform linux/amd64 -t logstore-node -f ./Dockerfile --cache-from type=gha,scope=usherlabs/logstore-node --cache-to type=gha,mode=max,scope=usherlabs/logstore-node .
+#      - name: Build image
+#        run: |
+#          docker build --platform linux/amd64 -t logstore-node -f ./Dockerfile --cache-from type=gha,scope=usherlabs/logstore-node --cache-to type=gha,mode=max,scope=usherlabs/logstore-node .
 
-      - name: Tag image
+      - name: Create image name
         run: |
           # if master, tag as latest
           tag=latest
@@ -45,13 +45,15 @@ jobs:
           if [ $GITHUB_REF != 'refs/heads/master' ]; then
               tag=$(echo $GITHUB_REF | sed 's/refs\/heads\///' | sed 's/\//-/')
           fi
-          image_name=${{ env.REGISTRY }}/$GITHUB_REPOSITORY/logstore-node:$tag
-          docker tag logstore-node $image_name
-          echo "Tagged image as $image_name"
+          image_name=${{ env.REGISTRY }}/usherlabs/logstore-node:$tag
           # save for next step
           echo "image_name=$image_name" >> $GITHUB_ENV
 
-      - name: Push image to GitHub Container Registry
-        if: ${{ !env.ACT }} # skip during local actions testing
-        run: |
-          docker push $image_name
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.image_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
A new GitHub Actions workflow has been added to build and deploy Docker images. This workflow triggers on pushes to the master and develop branches as well as manual dispatch. The Docker image is built, tagged according to branch or as 'latest', and then pushed to GitHub Container Registry.