### PR TITLE
fix: failing docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY ./packages/mpc-tls/scripts/protoc.sh ./script.sh
 RUN sh ./script.sh
 
 
-FROM ubuntu:latest
+FROM ubuntu:22.04
 RUN apt update
 RUN apt install -y libsecret-1-dev cmake
 


### PR DESCRIPTION
The Dockerfile has been updated to pull from Ubuntu 22.04 instead of using the latest version. 
It fixes the current errors we're getting