### PR TITLE
feat: include arm64 docker build in action

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -81,7 +81,7 @@ jobs:
           path: ./Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -75,8 +75,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
       - name: Export digest
         run: |
@@ -96,6 +96,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Prepare
         run: |

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -115,9 +115,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    envs:
-      IMAGE_NAME: ${{ needs.build.outputs.image_name }}
     steps:
+      - name: Prepare
+        run: |
+          # setup env vars
+          echo "IMAGE_NAME=${{ needs.build.outputs.image_name }}" >> $GITHUB_ENV
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/usherlabs/logstore-node
 
 jobs:
   build:
@@ -27,7 +28,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-#          - linux/arm64
+          - linux/arm64
     steps:
       - name: Create image name
         run: |
@@ -57,11 +58,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/usherlabs/logstore-node
+          images: ${{ env.IMAGE_NAME }}
           # tags = latest if master, and branch name
           tags: |
-            type=ref,event=branch
             type=raw,enabled=${{ env.GITHUB_REF == 'refs/heads/master' }},value=latest
+            type=ref,event=branch
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -85,7 +86,7 @@ jobs:
           path: ./Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -127,7 +128,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/usherlabs/logstore-node
+          # tags = latest if master, and branch name
+          tags: |
+            type=raw,enabled=${{ env.GITHUB_REF == 'refs/heads/master' }},value=latest
+            type=ref,event=branch
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -30,18 +30,6 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - name: Create image name
-        run: |
-          # if master, tag as latest
-          tag=latest
-          # if not master, tag as branch name
-          if [ $GITHUB_REF != 'refs/heads/master' ]; then
-              tag=$(echo $GITHUB_REF | sed 's/refs\/heads\///' | sed 's/\//-/')
-          fi
-          image_name=:$tag
-          # save for next step
-          echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
-
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - develop
+      - dev
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -12,36 +12,23 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  deploy:
-    name: Deploy Docker Image
+  build:
+    name: Build Docker Image
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       packages: write
 
+    outputs:
+      image_name: ${{ env.IMAGE_NAME }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        if: ${{ !env.ACT }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-#      - name: Build image
-#        run: |
-#          docker build --platform linux/amd64 -t logstore-node -f ./Dockerfile --cache-from type=gha,scope=usherlabs/logstore-node --cache-to type=gha,mode=max,scope=usherlabs/logstore-node .
-
       - name: Create image name
         run: |
           # if master, tag as latest
@@ -52,15 +39,117 @@ jobs:
           fi
           image_name=${{ env.REGISTRY }}/usherlabs/logstore-node:$tag
           # save for next step
-          echo "image_name=$image_name" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
 
-      - name: Build and push
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        if: ${{ !env.ACT }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      #      - name: Build and push amd64
+      #        uses: docker/build-push-action@v5
+      #        with:
+      #          context: .
+      #          builder: ${{ steps.setup-builder.outputs.name }}
+      #          # we push only if env.ACT is not set
+      #          push: ${{ env.ACT == '' }}
+      #          tags: ${{ env.image_name }}
+      #          platforms: linux/${{ matrix.architecture }}
+      #          cache-from: type=gha
+      #          cache-to: type=gha,mode=max
+
+
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
-          # we push only if env.ACT is not set
-          push: ${{ env.ACT == '' }}
-          tags: ${{ env.image_name }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    envs:
+      IMAGE_NAME: ${{ needs.build.outputs.image_name }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        if: ${{ !env.ACT }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        if: ${{ env.ACT == '' }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -60,5 +60,6 @@ jobs:
           # we push only if env.ACT is not set
           push: ${{ env.ACT == '' }}
           tags: ${{ env.image_name }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -12,23 +12,32 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build:
-    name: Build Docker Image
+  deploy:
+    name: Deploy Docker Image
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
 
-    outputs:
-      image_name: ${{ env.IMAGE_NAME }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        if: ${{ !env.ACT }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Create image name
         run: |
           # if master, tag as latest
@@ -39,120 +48,162 @@ jobs:
           fi
           image_name=${{ env.REGISTRY }}/usherlabs/logstore-node:$tag
           # save for next step
-          echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
+          echo "image_name=$image_name" >> $GITHUB_ENV
 
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        if: ${{ !env.ACT }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      #      - name: Build and push amd64
-      #        uses: docker/build-push-action@v5
-      #        with:
-      #          context: .
-      #          builder: ${{ steps.setup-builder.outputs.name }}
-      #          # we push only if env.ACT is not set
-      #          push: ${{ env.ACT == '' }}
-      #          tags: ${{ env.image_name }}
-      #          platforms: linux/${{ matrix.architecture }}
-      #          cache-from: type=gha
-      #          cache-to: type=gha,mode=max
-
-
-      - name: Build and push by digest
-        id: build
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          # we push only if env.ACT is not set
+          push: ${{ env.ACT == '' }}
+          tags: ${{ env.image_name }}
+          platforms: linux/amd64, linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-      - name: Prepare
-        run: |
-          # setup env vars
-          echo "IMAGE_NAME=${{ needs.build.outputs.image_name }}" >> $GITHUB_ENV
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        if: ${{ !env.ACT }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        if: ${{ env.ACT == '' }}
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-
+## Commenting
+#  build:
+#    name: Build Docker Image
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: read
+#      packages: write
+#
+#    outputs:
+#      image_name: ${{ env.IMAGE_NAME }}
+#
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        platform:
+#          - linux/amd64
+#          - linux/arm64
+#    steps:
+#      - name: Create image name
+#        run: |
+#          # if master, tag as latest
+#          tag=latest
+#          # if not master, tag as branch name
+#          if [ $GITHUB_REF != 'refs/heads/master' ]; then
+#              tag=$(echo $GITHUB_REF | sed 's/refs\/heads\///' | sed 's/\//-/')
+#          fi
+#          image_name=${{ env.REGISTRY }}/usherlabs/logstore-node:$tag
+#          # save for next step
+#          echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
+#
+#      - name: Prepare
+#        run: |
+#          platform=${{ matrix.platform }}
+#          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+#
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#        with:
+#          submodules: true
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#
+#
+#      - name: Docker meta
+#        id: meta
+#        uses: docker/metadata-action@v5
+#        with:
+#          images: ${{ env.IMAGE_NAME }}
+#
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v3
+#
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#
+#      - name: Log in to the Container registry
+#        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+#        if: ${{ !env.ACT }}
+#        with:
+#          registry: ${{ env.REGISTRY }}
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#
+#      #      - name: Build and push amd64
+#      #        uses: docker/build-push-action@v5
+#      #        with:
+#      #          context: .
+#      #          builder: ${{ steps.setup-builder.outputs.name }}
+#      #          # we push only if env.ACT is not set
+#      #          push: ${{ env.ACT == '' }}
+#      #          tags: ${{ env.image_name }}
+#      #          platforms: linux/${{ matrix.architecture }}
+#      #          cache-from: type=gha
+#      #          cache-to: type=gha,mode=max
+#
+#
+#      - name: Build and push by digest
+#        id: build
+#        uses: docker/build-push-action@v5
+#        with:
+#          context: .
+#          platforms: ${{ matrix.platform }}
+#          labels: ${{ steps.meta.outputs.labels }}
+#          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
+#
+#      - name: Export digest
+#        run: |
+#          mkdir -p /tmp/digests
+#          digest="${{ steps.build.outputs.digest }}"
+#          touch "/tmp/digests/${digest#sha256:}"
+#
+#      - name: Upload digest
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: digests-${{ env.PLATFORM_PAIR }}
+#          path: /tmp/digests/*
+#          if-no-files-found: error
+#          retention-days: 1
+#
+#  merge:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - build
+#    steps:
+#      - name: Prepare
+#        run: |
+#          # setup env vars
+#          echo "IMAGE_NAME=${{ needs.build.outputs.image_name }}" >> $GITHUB_ENV
+#
+#      - name: Download digests
+#        uses: actions/download-artifact@v4
+#        with:
+#          path: /tmp/digests
+#          pattern: digests-*
+#          merge-multiple: true
+#
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#
+#      - name: Docker meta
+#        id: meta
+#        uses: docker/metadata-action@v5
+#        with:
+#          images: ${{ env.IMAGE_NAME }}
+#
+#      - name: Log in to the Container registry
+#        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+#        if: ${{ !env.ACT }}
+#        with:
+#          registry: ${{ env.REGISTRY }}
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Create manifest list and push
+#        working-directory: /tmp/digests
+#        if: ${{ env.ACT == '' }}
+#        run: |
+#          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+#            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+#
+#      - name: Inspect image
+#        run: |
+#          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+#

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -12,32 +12,23 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  deploy:
-    name: Deploy Docker Image
+  build:
+    name: Build Docker Image
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       packages: write
 
+    outputs:
+      image_name: ${{ env.IMAGE_NAME }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+#          - linux/arm64
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        if: ${{ !env.ACT }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Create image name
         run: |
           # if master, tag as latest
@@ -48,162 +39,108 @@ jobs:
           fi
           image_name=${{ env.REGISTRY }}/usherlabs/logstore-node:$tag
           # save for next step
-          echo "image_name=$image_name" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
 
-      - name: Build and push
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        if: ${{ !env.ACT }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
-          # we push only if env.ACT is not set
-          push: ${{ env.ACT == '' }}
-          tags: ${{ env.image_name }}
-          platforms: linux/amd64, linux/arm64
+          path: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
 
-## Commenting
-#  build:
-#    name: Build Docker Image
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: read
-#      packages: write
-#
-#    outputs:
-#      image_name: ${{ env.IMAGE_NAME }}
-#
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        platform:
-#          - linux/amd64
-#          - linux/arm64
-#    steps:
-#      - name: Create image name
-#        run: |
-#          # if master, tag as latest
-#          tag=latest
-#          # if not master, tag as branch name
-#          if [ $GITHUB_REF != 'refs/heads/master' ]; then
-#              tag=$(echo $GITHUB_REF | sed 's/refs\/heads\///' | sed 's/\//-/')
-#          fi
-#          image_name=${{ env.REGISTRY }}/usherlabs/logstore-node:$tag
-#          # save for next step
-#          echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
-#
-#      - name: Prepare
-#        run: |
-#          platform=${{ matrix.platform }}
-#          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-#
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#        with:
-#          submodules: true
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#
-#
-#      - name: Docker meta
-#        id: meta
-#        uses: docker/metadata-action@v5
-#        with:
-#          images: ${{ env.IMAGE_NAME }}
-#
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v3
-#
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#
-#      - name: Log in to the Container registry
-#        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-#        if: ${{ !env.ACT }}
-#        with:
-#          registry: ${{ env.REGISTRY }}
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#
-#      #      - name: Build and push amd64
-#      #        uses: docker/build-push-action@v5
-#      #        with:
-#      #          context: .
-#      #          builder: ${{ steps.setup-builder.outputs.name }}
-#      #          # we push only if env.ACT is not set
-#      #          push: ${{ env.ACT == '' }}
-#      #          tags: ${{ env.image_name }}
-#      #          platforms: linux/${{ matrix.architecture }}
-#      #          cache-from: type=gha
-#      #          cache-to: type=gha,mode=max
-#
-#
-#      - name: Build and push by digest
-#        id: build
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: .
-#          platforms: ${{ matrix.platform }}
-#          labels: ${{ steps.meta.outputs.labels }}
-#          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
-#
-#      - name: Export digest
-#        run: |
-#          mkdir -p /tmp/digests
-#          digest="${{ steps.build.outputs.digest }}"
-#          touch "/tmp/digests/${digest#sha256:}"
-#
-#      - name: Upload digest
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: digests-${{ env.PLATFORM_PAIR }}
-#          path: /tmp/digests/*
-#          if-no-files-found: error
-#          retention-days: 1
-#
-#  merge:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - build
-#    steps:
-#      - name: Prepare
-#        run: |
-#          # setup env vars
-#          echo "IMAGE_NAME=${{ needs.build.outputs.image_name }}" >> $GITHUB_ENV
-#
-#      - name: Download digests
-#        uses: actions/download-artifact@v4
-#        with:
-#          path: /tmp/digests
-#          pattern: digests-*
-#          merge-multiple: true
-#
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#
-#      - name: Docker meta
-#        id: meta
-#        uses: docker/metadata-action@v5
-#        with:
-#          images: ${{ env.IMAGE_NAME }}
-#
-#      - name: Log in to the Container registry
-#        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-#        if: ${{ !env.ACT }}
-#        with:
-#          registry: ${{ env.REGISTRY }}
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Create manifest list and push
-#        working-directory: /tmp/digests
-#        if: ${{ env.ACT == '' }}
-#        run: |
-#          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-#            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
-#
-#      - name: Inspect image
-#        run: |
-#          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-#
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Prepare
+        run: |
+          # setup env vars
+          echo "IMAGE_NAME=${{ needs.build.outputs.image_name }}" >> $GITHUB_ENV
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        if: ${{ env.ACT == '' }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        if: ${{ env.ACT == '' }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -49,7 +49,7 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           # tags = latest if master, and branch name
           tags: |
-            type=raw,enabled=${{ env.GITHUB_REF == 'refs/heads/master' }},value=latest
+            type=raw,enable=${{ env.GITHUB_REF == 'refs/heads/master' }},value=latest
             type=ref,event=branch
 
       - name: Set up QEMU
@@ -119,7 +119,7 @@ jobs:
           images: ${{ env.REGISTRY }}/usherlabs/logstore-node
           # tags = latest if master, and branch name
           tags: |
-            type=raw,enabled=${{ env.GITHUB_REF == 'refs/heads/master' }},value=latest
+            type=raw,enable=${{ env.GITHUB_REF == 'refs/heads/master' }},value=latest
             type=ref,event=branch
 
       - name: Log in to the Container registry

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -37,7 +37,7 @@ jobs:
           if [ $GITHUB_REF != 'refs/heads/master' ]; then
               tag=$(echo $GITHUB_REF | sed 's/refs\/heads\///' | sed 's/\//-/')
           fi
-          image_name=${{ env.REGISTRY }}/usherlabs/logstore-node:$tag
+          image_name=:$tag
           # save for next step
           echo "IMAGE_NAME=$image_name" >> $GITHUB_ENV
 
@@ -57,7 +57,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/usherlabs/logstore-node
+          # tags = latest if master, and branch name
+          tags: |
+            type=ref,event=branch
+            type=raw,enabled=${{ env.GITHUB_REF == 'refs/heads/master' }},value=latest
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
In the deployment process, Docker now builds images for both `linux/amd64` and `linux/arm64` platforms. This addition allows for a more inclusive deployment of the image across different platforms.