### PR TITLE
fix: can register stream id after joining error

### DIFF
--- a/packages/core/src/plugins/logStore/network/LogStoreNetworkPlugin.ts
+++ b/packages/core/src/plugins/logStore/network/LogStoreNetworkPlugin.ts
@@ -144,12 +144,17 @@ export class LogStoreNetworkPlugin extends LogStorePlugin {
 			{
 				onStreamPartAdded: async (streamPart) => {
 					try {
-						await node.join(streamPart, { minCount: 1, timeout: 5000 }); // best-effort, can time out
+						await node
+							.join(streamPart, { minCount: 1, timeout: 5000 })
+							.catch(() => {}); // best-effort, can time out. No-op on error
 						await this.nodeStreamsRegistry.registerStreamId(
 							StreamPartIDUtils.getStreamID(streamPart)
 						);
-					} catch (_e) {
-						// no-op
+					} catch (e) {
+						logger.error('error after joining stream', {
+							error: e,
+							streamPart,
+						});
 					}
 					try {
 						// TODO: Temporary disabled sending of assignment messages through the system stream.

--- a/packages/core/src/plugins/logStore/standalone/LogStoreStandalonePlugin.ts
+++ b/packages/core/src/plugins/logStore/standalone/LogStoreStandalonePlugin.ts
@@ -4,13 +4,15 @@ import {
 	toStreamID,
 	toStreamPartID,
 } from '@streamr/protocol';
-import { executeSafePromise } from '@streamr/utils';
+import { executeSafePromise, Logger } from '@streamr/utils';
 import _ from 'lodash';
 
 import { PluginOptions, StandaloneModeConfig } from '../../../Plugin';
 import { BaseQueryRequestManager } from '../BaseQueryRequestManager';
 import { LogStorePlugin } from '../LogStorePlugin';
 import { LogStoreStandaloneConfig } from './LogStoreStandaloneConfig';
+
+const logger = new Logger(module);
 
 export class LogStoreStandalonePlugin extends LogStorePlugin {
 	private standaloneQueryRequestManager: BaseQueryRequestManager;
@@ -65,12 +67,17 @@ export class LogStoreStandalonePlugin extends LogStorePlugin {
 		const logStoreConfig = new LogStoreStandaloneConfig(streamPartIds, {
 			onStreamPartAdded: async (streamPart) => {
 				try {
-					await node.join(streamPart, { minCount: 1, timeout: 5000 }); // best-effort, can time out
+					await node
+						.join(streamPart, { minCount: 1, timeout: 5000 })
+						.catch(() => {}); // best-effort, can time out. No-op on error
 					await this.nodeStreamsRegistry.registerStreamId(
 						StreamPartIDUtils.getStreamID(streamPart)
 					);
-				} catch (_e) {
-					// no-op
+				} catch (e) {
+					logger.error('error after joining stream', {
+						error: e,
+						streamPart,
+					});
 				}
 			},
 			onStreamPartRemoved: async (streamPart) => {


### PR DESCRIPTION
The bug happened because errors can happen during stream partition join, blocking the next code from happening.

However the node still works even after this fail because there is an internal retry mechanism from joining stream parts.

A noop catch clause made it continue again. In the LogStoreNetworkPlugin, the code has been updated to handle exceptions when joining a stream, suppressing the error as a no-operation, and catch block has been altered to log the error details for better error insight. This will help in identifying any potential issues that might occur while joining the stream.