### PR TITLE
feat: log register and unregistered streams

### DIFF
--- a/packages/core/src/plugins/logStore/NodeStreamsRegistry.ts
+++ b/packages/core/src/plugins/logStore/NodeStreamsRegistry.ts
@@ -1,5 +1,7 @@
 import StreamrClient, { Stream } from '@streamr/sdk';
-import { ObservableEventEmitter } from '@streamr/utils';
+import { Logger, ObservableEventEmitter } from '@streamr/utils';
+
+const logger = new Logger(module);
 
 export class NodeStreamsRegistry extends ObservableEventEmitter<{
 	registerStream: (stream: Stream) => void;
@@ -22,6 +24,8 @@ export class NodeStreamsRegistry extends ObservableEventEmitter<{
 		const stream = await this.streamrClient.getStream(streamId);
 		this.registeredStreams.set(streamId, stream);
 
+	  logger.info('Registered stream to be tracked', { streamId });
+
 		this.emit('registerStream', stream);
 	}
 
@@ -31,6 +35,8 @@ export class NodeStreamsRegistry extends ObservableEventEmitter<{
 			return;
 		}
 		this.registeredStreams.delete(streamId);
+
+		logger.info('Unregistered stream from being tracked', { streamId });
 
 		this.emit('unregisterStream', stream);
 	}


### PR DESCRIPTION
e.g.
```
INFO [2024-06-07T13:15:29.570] (NodeStreamsRegistry      ): Registered stream to be tracked {"streamId":"0xd37dc4d7e2c1bdf3edd89db0e505394ea69af43d/kwil-demo"}
```