### PR TITLE
feat: case insensitive stream Ids requests

### DIFF
--- a/packages/core/src/plugins/logStore/LogStore.ts
+++ b/packages/core/src/plugins/logStore/LogStore.ts
@@ -1,4 +1,4 @@
-import { StreamMessage } from '@streamr/protocol';
+import { StreamMessage, toStreamID } from '@streamr/protocol';
 import { Logger, MetricsContext, RateMetric } from '@streamr/utils';
 import { Readable } from 'stream';
 
@@ -58,10 +58,11 @@ export class LogStore extends DatabaseEventEmitter {
 		partition: number,
 		requestCount: number
 	): Readable {
+		const verifiedStreamId = toStreamID(streamId);
 		if (requestCount < 0) {
-			return this.db.queryFirst(streamId, partition, -requestCount);
+			return this.db.queryFirst(verifiedStreamId, partition, -requestCount);
 		} else {
-			return this.db.queryLast(streamId, partition, requestCount);
+			return this.db.queryLast(verifiedStreamId, partition, requestCount);
 		}
 	}
 
@@ -84,7 +85,7 @@ export class LogStore extends DatabaseEventEmitter {
 
 		return this.db
 			.queryRange(
-				streamId,
+				toStreamID(streamId),
 				partition,
 				fromTimestamp,
 				fromSequenceNo,
@@ -130,7 +131,7 @@ export class LogStore extends DatabaseEventEmitter {
 		}
 		return this.db
 			.queryRange(
-				streamId,
+				toStreamID(streamId),
 				partition,
 				fromTimestamp,
 				fromSequenceNo,
@@ -166,7 +167,7 @@ export class LogStore extends DatabaseEventEmitter {
 		partition: number
 	): Promise<number> {
 		const firstMessageDateInStream = await this.db.getFirstMessageDateInStream(
-			streamId,
+			toStreamID(streamId),
 			partition
 		);
 		return firstMessageDateInStream
@@ -179,7 +180,7 @@ export class LogStore extends DatabaseEventEmitter {
 		partition: number
 	): Promise<number> {
 		const lastMessageDateInStream = await this.db.getLastMessageDateInStream(
-			streamId,
+			toStreamID(streamId),
 			partition
 		);
 		return lastMessageDateInStream
@@ -191,14 +192,14 @@ export class LogStore extends DatabaseEventEmitter {
 		streamId: string,
 		partition: number
 	): Promise<number> {
-		return this.db.getNumberOfMessagesInStream(streamId, partition);
+		return this.db.getNumberOfMessagesInStream(toStreamID(streamId), partition);
 	}
 
 	async getTotalBytesInStream(
 		streamId: string,
 		partition: number
 	): Promise<number> {
-		return this.db.getTotalBytesInStream(streamId, partition);
+		return this.db.getTotalBytesInStream(toStreamID(streamId), partition);
 	}
 
 	public async close(): Promise<void> {

--- a/packages/core/src/plugins/logStore/database/DatabaseAdapter.ts
+++ b/packages/core/src/plugins/logStore/database/DatabaseAdapter.ts
@@ -1,6 +1,7 @@
 import { MessageRef, StreamMessage } from '@streamr/protocol';
 import { Logger, ObservableEventEmitter } from '@streamr/utils';
 import { Readable } from 'stream';
+import { StreamID } from '@streamr/sdk';
 
 const logger = new Logger(module);
 
@@ -33,8 +34,10 @@ export abstract class DatabaseAdapter extends DatabaseEventEmitter {
 		super();
 	}
 
+	// Note: 	important to use `StreamID` for streamIds, because it checks the correct casing and format
+
 	abstract queryRange(
-		streamId: string,
+		streamId: StreamID,
 		partition: number,
 		fromTimestamp: number,
 		fromSequenceNo: number,
@@ -46,40 +49,40 @@ export abstract class DatabaseAdapter extends DatabaseEventEmitter {
 	): Readable;
 
 	abstract queryByMessageRefs(
-		streamId: string,
+		streamId: StreamID,
 		partition: number,
 		messageRefs: MessageRef[]
 	): Readable;
 
 	abstract queryFirst(
-		streamId: string,
+		streamId: StreamID,
 		partition: number,
 		requestCount: number
 	): Readable;
 
 	abstract queryLast(
-		streamId: string,
+		streamId: StreamID,
 		partition: number,
 		requestCount: number
 	): Readable;
 
 	abstract getFirstMessageDateInStream(
-		streamId: string,
+		streamId: StreamID,
 		partition: number
 	): Promise<number | null>;
 
 	abstract getLastMessageDateInStream(
-		streamId: string,
+		streamId: StreamID,
 		partition: number
 	): Promise<number | null>;
 
 	abstract getNumberOfMessagesInStream(
-		streamId: string,
+		streamId: StreamID,
 		partition: number
 	): Promise<number>;
 
 	abstract getTotalBytesInStream(
-		streamId: string,
+		streamId: StreamID,
 		partition: number
 	): Promise<number>;
 

--- a/packages/core/src/plugins/logStore/http/dataQueryEndpoint.ts
+++ b/packages/core/src/plugins/logStore/http/dataQueryEndpoint.ts
@@ -20,6 +20,7 @@ import { sendError, sendSuccess } from './httpHelpers';
 import { injectLogstoreContextMiddleware } from './injectLogstoreContextMiddleware';
 import { FromRequest, LastRequest, RangeRequest } from './requestTypes';
 
+const logger = new Logger(module);
 
 // TODO: move this to protocol-js
 export const MIN_SEQUENCE_NUMBER_VALUE = 0;
@@ -100,6 +101,10 @@ const getDataForRequest = async (
 
 const createHandler = (metrics: MetricsDefinition): RequestHandler => {
 	return async (req: Request, res: Response) => {
+		logger.debug('Received HTTP data query request', {
+			query: req.query,
+			params: req.params,
+		});
 		if (Number.isNaN(parseInt(req.params.partition))) {
 			sendError(
 				`Path parameter "partition" not a number: ${req.params.partition}`,

--- a/packages/core/src/plugins/logStore/http/dataQueryEndpoint.ts
+++ b/packages/core/src/plugins/logStore/http/dataQueryEndpoint.ts
@@ -2,6 +2,7 @@
  * Endpoints for RESTful data requests
  */
 import {
+	Logger,
 	MetricsContext,
 	MetricsDefinition,
 	RateMetric,
@@ -20,6 +21,7 @@ import { sendError, sendSuccess } from './httpHelpers';
 import { injectLogstoreContextMiddleware } from './injectLogstoreContextMiddleware';
 import { FromRequest, LastRequest, RangeRequest } from './requestTypes';
 
+const logger = new Logger(module);
 
 // TODO: move this to protocol-js
 export const MIN_SEQUENCE_NUMBER_VALUE = 0;
@@ -100,6 +102,10 @@ const getDataForRequest = async (
 
 const createHandler = (metrics: MetricsDefinition): RequestHandler => {
 	return async (req: Request, res: Response) => {
+		logger.debug('Received HTTP data query request', {
+			query: req.query,
+			params: req.params,
+		});
 		if (Number.isNaN(parseInt(req.params.partition))) {
 			sendError(
 				`Path parameter "partition" not a number: ${req.params.partition}`,

--- a/packages/core/src/plugins/logStore/network/Aggregator.ts
+++ b/packages/core/src/plugins/logStore/network/Aggregator.ts
@@ -5,7 +5,7 @@ import {
 	QueryResponse,
 	QueryType,
 } from '@logsn/protocol';
-import { MessageRef } from '@streamr/protocol';
+import { MessageRef, toStreamID } from '@streamr/protocol';
 import { convertBytesToStreamMessage } from '@streamr/trackerless-network';
 import { EthereumAddress, Logger } from '@streamr/utils';
 import { PassThrough, pipeline, Readable } from 'stream';
@@ -70,18 +70,20 @@ export class Aggregator extends PassThrough {
 		this.aggregationList = new AggregationList();
 		this.queryStreams = new Set<Readable>();
 
+		const streamId = toStreamID(this.queryRequest.streamId);
+
 		let queryStream: Readable;
 		switch (this.queryRequest.queryOptions.queryType) {
 			case QueryType.Last:
 				queryStream = this.database.queryLast(
-					this.queryRequest.streamId,
+					streamId,
 					this.queryRequest.partition,
 					this.queryRequest.queryOptions.last
 				);
 				break;
 			case QueryType.From:
 				queryStream = this.database.queryRange(
-					this.queryRequest.streamId,
+					streamId,
 					this.queryRequest.partition,
 					this.queryRequest.queryOptions.from.timestamp,
 					this.queryRequest.queryOptions.from.sequenceNumber ??
@@ -94,7 +96,7 @@ export class Aggregator extends PassThrough {
 				break;
 			case QueryType.Range:
 				queryStream = this.database.queryRange(
-					this.queryRequest.streamId,
+					streamId,
 					this.queryRequest.partition,
 					this.queryRequest.queryOptions.from.timestamp,
 					this.queryRequest.queryOptions.from.sequenceNumber ??
@@ -235,7 +237,7 @@ export class Aggregator extends PassThrough {
 
 			// TODO: Handle an error if the pipe gets broken
 			const queryStream = this.database.queryRange(
-				this.queryRequest.streamId,
+				toStreamID(this.queryRequest.streamId),
 				this.queryRequest.partition,
 				readyFrom.timestamp,
 				readyFrom.sequenceNumber,


### PR DESCRIPTION
achieved by requiring `StreamID` type on database handlers. The reasoning is that `toStreamID` helper normalizes it already.

- add tests to ensure it
- added debug logs on new query requests