### PR TITLE
feat: handle stream id with slashes in paths

### DIFF
--- a/packages/core/src/plugins/logStore/http/dataQueryEndpoint.ts
+++ b/packages/core/src/plugins/logStore/http/dataQueryEndpoint.ts
@@ -167,7 +167,9 @@ export const createDataQueryEndpoint = (
 	};
 	metricsContext.addMetrics('broker.plugin.logstore', metrics);
 	return {
-		path: `/stores/:id/data/partitions/:partition/:queryType`,
+		// permit usage of slashes in paths
+		// \S = non-whitespace character, we use it because `.` doesn't work well with express in this context
+		path: `/stores/:id(\\S+\?)/data/partitions/:partition/:queryType`,
 		method: 'get',
 		requestHandlers: [
 			// We need to inject it here, because the execution context from

--- a/packages/core/src/plugins/logStore/http/readyEndpoint.ts
+++ b/packages/core/src/plugins/logStore/http/readyEndpoint.ts
@@ -102,7 +102,7 @@ export const createReadyEndpoint = (): HttpServerEndpoint => {
 	const ctx = logStoreContext.getStore();
 
 	return {
-		path: `/stores/:id/partitions/:partition/ready`,
+		path: `/stores/:id(\\S+\?)/partitions/:partition/ready`,
 		method: 'get',
 		requestHandlers: [
 			// We need to inject it here, because the execution context from

--- a/packages/core/test/integration/plugins/logStore/http-server/http.test.ts
+++ b/packages/core/test/integration/plugins/logStore/http-server/http.test.ts
@@ -23,12 +23,14 @@ import {
 } from '@streamr/test-utils';
 import {
 	hexToBinary,
+	MetricsContext,
 	toEthereumAddress,
 	verifySignature,
 	wait,
 } from '@streamr/utils';
 import axios from 'axios';
 import { Wallet } from 'ethers';
+import { Request, RequestHandler, Response } from 'express';
 import { range } from 'lodash';
 import { Readable } from 'stream';
 
@@ -63,6 +65,32 @@ jest.mock('../../../../../src/plugins/logStore/http/constants', () => {
 		get EVENTS_PER_RESPONSE_LIMIT_ON_NON_STREAM() {
 			return mockTestLimit;
 		},
+	};
+});
+
+const dataQueryTestMiddleware = jest.fn();
+
+jest.mock('../../../../../src/plugins/logStore/http/dataQueryEndpoint', () => {
+	const originalModule = jest.requireActual(
+		'../../../../../src/plugins/logStore/http/dataQueryEndpoint'
+	);
+
+	const originalFn = (metrics: MetricsContext) => {
+		const originalResult = originalModule.createDataQueryEndpoint(metrics);
+		return {
+			...originalResult,
+			requestHandlers: [
+				(req, res, next) => {
+					dataQueryTestMiddleware(req, res, next);
+				},
+				...originalResult.requestHandlers,
+			] as RequestHandler[],
+		};
+	};
+
+	return {
+		...originalModule,
+		createDataQueryEndpoint: originalFn,
 	};
 });
 
@@ -583,7 +611,65 @@ describe('http works', () => {
 					// it's ready because the nodes are already connected to it
 					expect(res.data).toStrictEqual({ ready: true });
 				});
-		}, 9999999);
+		});
+	});
+
+	describe('endpoints are triggered as expected', () => {
+		test('encoded stream id', async () => {
+			// this test works by mocking the data query middleware
+			// in the log store module
+			// we expect the middleware to be called with the correct params at least once,
+			// indicating that the endpoint is triggered for this endpoint
+
+			const encodedStreamId = encodeURIComponent(testStream.id);
+			const { token } = await consumerLogStoreClient.apiAuth();
+			const endpoint = `${BROKER_URL}/stores/${encodedStreamId}/data/partitions/0/last`;
+			// mock endpoint handler
+			dataQueryTestMiddleware.mockImplementationOnce(
+				(req: Request, res: Response) => {
+					expect(req.params.id).toBe(testStream.id);
+					expect(req.params.partition).toBe('0');
+					expect(req.params.queryType).toBe('last');
+					res.json({ ready: true });
+				}
+			);
+
+			await axios
+				.get(endpoint, { headers: { authorization: `Bearer ${token}` } })
+				.then((res) => {
+					// it's ready because the nodes are already connected to it
+					expect(res.data).toStrictEqual({ ready: true });
+				});
+
+			expect(dataQueryTestMiddleware).toHaveBeenCalledTimes(1);
+		});
+
+		test('plain stream id', async () => {
+			// this test works by mocking the data query middleware
+			// in the log store module
+			// we expect the middleware to be called with the correct params at least once,
+			// indicating that the endpoint is triggered for this endpoint
+
+			const { token } = await consumerLogStoreClient.apiAuth();
+			const endpoint = `${BROKER_URL}/stores/${testStream.id}/data/partitions/0/last`;
+			// mock endpoint handler
+			dataQueryTestMiddleware.mockImplementationOnce(
+				(req: Request, res: Response) => {
+					expect(req.params.id).toBe(testStream.id);
+					expect(req.params.partition).toBe('0');
+					expect(req.params.queryType).toBe('last');
+					res.json({ ready: true });
+				}
+			);
+
+			await axios
+				.get(endpoint, { headers: { authorization: `Bearer ${token}` } })
+				.then((res) => {
+					// it's ready because the nodes are already connected to it
+					expect(res.data).toStrictEqual({ ready: true });
+				});
+			expect(dataQueryTestMiddleware).toHaveBeenCalledTimes(1);
+		});
 	});
 });
 


### PR DESCRIPTION
workaround: use `\S` instead of `.` as the later doesn't work well with express.

create tests to persist the behavior